### PR TITLE
Add information about setting up the sandbox for local development.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@
 
 # Ignore IDE files
 .idea/
+
+# Ignore a local development copy of drupal8-rector that won't be overwritten by composer.
+/drupal8-rector/
+/rector.yml
+/web/modules/custom/rector_examples

--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,4 @@
 
 # Ignore a local development copy of drupal8-rector that won't be overwritten by composer.
 /drupal8-rector/
-/rector.yml
 /web/modules/custom/rector_examples

--- a/README.md
+++ b/README.md
@@ -107,6 +107,34 @@ You can view the Rector report by running
 Rector can update your code by running
 `vendor/bin/rector process web/modules/custom/my-module`
 
+## Developing with Drupal Rector
+
+For development, it may be helpful to store a local copy of the drupal8-rector Git repository and symlink a few files and folders.
+
+Download the repository into the root of this directory,
+
+`git clone git@github.com:palantirnet/drupal8-rector.git`
+
+Remove the composer version and symlink the full repository,
+
+_You will need to modify the full paths with your path to the files / folders. If you are within the VM, these will be different. You can use `pwd` to find the path._
+
+```
+rm -Rf vendor/palantirnet/drupal8-rector
+ln -s /Users/[YOUR USERNAME]/Sites/drupal8-rector-sandbox/drupal8-rector vendor/palantirnet/drupal8-rector
+```
+
+Symlink the configuration file
+
+`ln -s /Users/[YOUR USERNAME]/Sites/drupal8-rector-sandbox/vendor/palantirnet/drupal8-rector/rector.yml rector.yml`
+
+Symlink the example module
+
+`ln -s /Users/[YOUR USERNAME]/Sites/drupal8-rector-sandbox/drupal8-rector/rector_examples web/modules/custom/rector_examples`
+
+Run Rector against the examples
+
+`vendor/bin/rector process web/modules/custom/rector_examples --dry-run`
 
 ## Drupal Development
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,12 @@ rm -Rf vendor/palantirnet/drupal8-rector
 ln -s /Users/[YOUR USERNAME]/Sites/drupal8-rector-sandbox/drupal8-rector vendor/palantirnet/drupal8-rector
 ```
 
-Symlink the configuration file
+Remove the default configuration and symlink the one from drupal8-rector,
 
-`ln -s /Users/[YOUR USERNAME]/Sites/drupal8-rector-sandbox/vendor/palantirnet/drupal8-rector/rector.yml rector.yml`
+```
+rm rector.yml
+ln -s /Users/[YOUR USERNAME]/Sites/drupal8-rector-sandbox/vendor/palantirnet/drupal8-rector/rector.yml rector.yml
+```
 
 Symlink the example module
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,60 @@ This is the development repository for the Drupal 8 Rector Sandbox. It contains 
 
 ## Table of Contents
 
+* [Running Drupal Rector](#running-drupal-rector)
+* [Developing with Drupal Rector](#developing-with-drupal-rector)
 * [Development Environment](#development-environment)
 * [Getting Started](#getting-started)
 * [How do I work on this?](#how-do-i-work-on-this)
-* [Running Drupal Rector](#running-drupal-rector)
 * [Drupal Development](#drupal-development)
+
+## Running Drupal Rector
+
+Initial setup: In Drupal root directory, Create or copy the initial rector.yml file -
+`cp vendor/palantirnet/drupal8-rector/rector.yml .`
+
+You can view the Rector report by running
+`vendor/bin/rector process web/modules/custom/my-module --dry-run`
+
+Rector can update your code by running
+`vendor/bin/rector process web/modules/custom/my-module`
+
+## Developing with Drupal Rector
+
+For development, it may be helpful to store a local copy of the drupal8-rector Git repository and symlink a few files and folders.
+
+Download the repository into the root of this directory,
+
+`git clone git@github.com:palantirnet/drupal8-rector.git`
+
+Remove the composer version and symlink the full repository,
+
+```
+rm -rf vendor/palantirnet/drupal8-rector
+ln -s ../../drupal8-rector vendor/palantirnet/drupal8-rector
+```
+
+Remove the default configuration and symlink the one from drupal8-rector,
+
+```
+rm rector.yml
+ln -s vendor/palantirnet/drupal8-rector/rector.yml rector.yml
+```
+
+If you do not have a `web/modules/custom` directory, create one
+```
+mkdir web/modules/custom
+```
+
+Symlink the example module into the custom modules directory
+
+```
+ln -s ../../../drupal8-rector/rector_examples web/modules/custom/rector_examples
+```
+
+Run Rector against the examples
+
+`vendor/bin/rector process web/modules/custom/rector_examples --dry-run`
 
 ## Development Environment
 
@@ -95,49 +144,6 @@ To run project-related commands other than `vagrant up` and `vagrant ssh`:
 * View email sent by your development site at [http://d8rector-sandbox.ddev.site:8025](http://d8rector-sandbox.ddev.site:8025)
 * Additional questions:
   * `#ddev` channel on [Drupal Slack](https://drupal.slack.com) (a new account can be created through http://drupalslack.herokuapp.com/)
-
-## Running Drupal Rector
-
-Initial setup: In Drupal root directory, Create or copy the initial rector.yml file -
-`cp vendor/drupal8-rector/drupal8-rector/rector.yml .`
-
-You can view the Rector report by running
-`vendor/bin/rector process web/modules/custom/my-module --dry-run`
-
-Rector can update your code by running
-`vendor/bin/rector process web/modules/custom/my-module`
-
-## Developing with Drupal Rector
-
-For development, it may be helpful to store a local copy of the drupal8-rector Git repository and symlink a few files and folders.
-
-Download the repository into the root of this directory,
-
-`git clone git@github.com:palantirnet/drupal8-rector.git`
-
-Remove the composer version and symlink the full repository,
-
-_You will need to modify the full paths with your path to the files / folders. If you are within the VM, these will be different. You can use `pwd` to find the path._
-
-```
-rm -Rf vendor/palantirnet/drupal8-rector
-ln -s /Users/[YOUR USERNAME]/Sites/drupal8-rector-sandbox/drupal8-rector vendor/palantirnet/drupal8-rector
-```
-
-Remove the default configuration and symlink the one from drupal8-rector,
-
-```
-rm rector.yml
-ln -s /Users/[YOUR USERNAME]/Sites/drupal8-rector-sandbox/vendor/palantirnet/drupal8-rector/rector.yml rector.yml
-```
-
-Symlink the example module
-
-`ln -s /Users/[YOUR USERNAME]/Sites/drupal8-rector-sandbox/drupal8-rector/rector_examples web/modules/custom/rector_examples`
-
-Run Rector against the examples
-
-`vendor/bin/rector process web/modules/custom/rector_examples --dry-run`
 
 ## Drupal Development
 

--- a/rector.yml
+++ b/rector.yml
@@ -1,13 +1,23 @@
 imports:
-  - { resource: "vendor/palantirnet/drupal8-rector/config/drupal8.yml" }
-  # - { resource: "config/drupal8.yml" }
+  - { resource: "vendor/palantirnet/drupal8-rector/config/drupal-8/drupal-8-all-deprecations.yml" }
+  # includes:
+  # - { resource: "vendor/palantirnet/drupal8-rector/config/drupal-8/drupal-8.5-deprecations.yml" }
+  # - { resource: "vendor/palantirnet/drupal8-rector/config/drupal-8/drupal-8.6-deprecations.yml" }
+  # - { resource: "vendor/palantirnet/drupal8-rector/config/drupal-8/drupal-8.7-deprecations.yml" }
 
 parameters:
   autoload_paths:
+    - 'web/core'
     - 'web/core/modules'
     - 'web/modules'
-  exclude_paths:
-    - '*/tests/*'
-    - '*/Tests/*'
+    - 'web/profiles'
 
-services:
+  file_extensions:
+    - module
+    - theme
+    - install
+    - profile
+    - inc
+    - engine
+
+services: ~


### PR DESCRIPTION
Added information about using symlinks to avoid having pieces be overwritten when composer is updated.

With https://github.com/palantirnet/drupal8-rector/pull/2 which includes an example module, we can test against and write example code.