### PR TITLE
Composer to use local package of drupal-rector

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,4 +1,3 @@
-APIVersion: v1.13.1
 name: drupal-rector-sandbox
 type: drupal8
 docroot: web
@@ -12,12 +11,11 @@ additional_fqdns: []
 nfs_mount_enabled: true
 provider: default
 use_dns_when_possible: true
-timezone: ""
 
 
-# This config.yaml was created with ddev version v1.13.1
-# webimage: drud/ddev-webserver:v1.13.1
-# dbimage: drud/ddev-dbserver-mariadb-10.2:v1.13.0
+# This config.yaml was created with ddev version v1.14.0
+# webimage: drud/ddev-webserver:v1.14.0
+# dbimage: drud/ddev-dbserver-mariadb-10.2:v1.14.0
 # dbaimage: phpmyadmin/phpmyadmin:5
 # However we do not recommend explicitly wiring these images into the
 # config.yaml as they may break future versions of ddev.
@@ -86,11 +84,11 @@ timezone: ""
 # These values specify the destination directory for ddev ssh and the
 # directory in which commands passed into ddev exec are run.
 
-# omit_containers: ["dba", "ddev-ssh-agent"]
-# would omit the dba (phpMyAdmin) and ddev-ssh-agent containers. Currently
-# only those two containers can be omitted here.
-# Note that these containers can also be omitted globally in the
-# ~/.ddev/global_config.yaml or with the "ddev config global" command.
+# omit_containers: ["db", dba", "ddev-ssh-agent"]
+# Currently only these containers are supported. Some containers can also be
+# omitted globally in the ~/.ddev/global_config.yaml. Note that if you omit
+# the "db" container, several standard features of ddev that access the
+# database container will be unusable.
 
 # nfs_mount_enabled: false
 # Great performance improvement but requires host configuration first.
@@ -112,11 +110,13 @@ timezone: ""
 # The host port binding for the ddev-dbserver can be explicitly specified. It is dynamic
 # unless explicitly specified.
 
-# phpmyadmin_port: "1000"
-# The PHPMyAdmin port can be changed from the default 8036
+# phpmyadmin_port: "8036"
+# phpmyadmin_https_port: "8037{"
+# The PHPMyAdmin ports can be changed from the default 8036 and 8037
 
-# mailhog_port: "1001"
-# The MailHog port can be changed from the default 8025
+# mailhog_port: "8025"
+# mailhog_https_port: "8026"
+# The MailHog ports can be changed from the default 8025 and 8026
 
 # webimage_extra_packages: [php-yaml, php7.3-ldap]
 # Extra Debian packages that are needed in the webimage can be added here
@@ -144,6 +144,12 @@ timezone: ""
 # If true, ddev will not create CMS-specific settings files like
 # Drupal's settings.php/settings.ddev.php or TYPO3's AdditionalSettings.php
 # In this case the user must provide all such settings.
+
+# no_project_mount: false
+# (Experimental) If true, ddev will not mount the project into the web container; 
+# the user is responsible for mounting it manually or via a script.
+# This is to enable experimentation with alternate file mounting strategies. 
+# For advanced users only!
 
 # provider: default # Currently either "default" or "pantheon"
 #

--- a/.github/workflows/drupal_rector_examples_as_local_package.yml
+++ b/.github/workflows/drupal_rector_examples_as_local_package.yml
@@ -1,0 +1,28 @@
+name: drupal_rector_sandbox
+
+# This test will run on every pull request, and on every commit on any branch
+on:
+    [push, pull_request]
+
+jobs:
+    drupal_rector_examples_as_local_package:
+        runs-on: ubuntu-latest
+        steps:
+            -   uses: actions/checkout@v2
+            -   uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 7.3
+                    coverage: none # disable xdebug, pcov
+                    extensions: "intl"
+
+#           Uncomment to enable SSH access to Github Actions - https://github.com/marketplace/actions/debugging-with-tmate#getting-started
+#            - name: Debugging with tmate
+#              uses: mxschmitt/action-tmate@v2
+
+            -   run: |
+                    # Run composer install (set to run 'develop-rector' script before)
+                    composer install
+
+            -   run: |
+                    # Run the latest drupal-rector with the included rector_examples
+                    vendor/bin/rector process web/modules/custom/rector_examples

--- a/.github/workflows/drupal_rector_examples_as_local_package.yml
+++ b/.github/workflows/drupal_rector_examples_as_local_package.yml
@@ -21,7 +21,7 @@ jobs:
 
             -   run: |
                     # Run composer install (set to run 'develop-rector' script before)
-                    composer install
+                    composer install --no-progress
 
             -   run: |
                     # Run the latest drupal-rector with the included rector_examples

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,13 @@
         "0": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        },
+        "drupal-rector": {
+            "type": "path",
+            "url": "drupal-rector",
+            "options": {
+                "symlink": true
+            }
         }
     },
     "require": {
@@ -20,7 +27,7 @@
         "drupal/config_split": "^1.4",
         "drupal/core-composer-scaffold": "^8.8",
         "drupal/core-recommended": "^8.8",
-        "palantirnet/drupal-rector": "^0.4.0",
+        "palantirnet/drupal-rector": "@dev",
         "zaporylie/composer-drupal-optimizations": "^1.1"
     },
     "require-dev": {
@@ -54,10 +61,10 @@
         "develop-rector": [
             "./develop-rector.sh"
         ],
-        "post-install-cmd": [
+        "pre-install-cmd": [
             "@develop-rector"
         ],
-        "post-update-cmd": [
+        "pre-update-cmd": [
             "@develop-rector"
         ]
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bbcdd67b31ec51e39ccbf7734e3282b6",
+    "content-hash": "51fd79943e4069ae2da52bf7cbb9c97b",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1609,17 +1609,11 @@
         },
         {
             "name": "palantirnet/drupal-rector",
-            "version": "0.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/palantirnet/drupal-rector.git",
-                "reference": "746c0d7880955a925c4d58379a95f2abe2fa5b8a"
-            },
+            "version": "dev-master",
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/palantirnet/drupal-rector/zipball/746c0d7880955a925c4d58379a95f2abe2fa5b8a",
-                "reference": "746c0d7880955a925c4d58379a95f2abe2fa5b8a",
-                "shasum": ""
+                "type": "path",
+                "url": "drupal-rector",
+                "reference": "bf48f9f782566a383ded9f26ffad3404f3d09a04"
             },
             "require": {
                 "jawira/case-converter": "^1.1",
@@ -1635,7 +1629,6 @@
                     "DrupalRector\\": "src"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -1655,13 +1648,15 @@
             ],
             "description": "Instant fixes for your Drupal code by using Rector.",
             "keywords": [
-                "Code style",
-                "Drupal 8",
                 "ast",
+                "code style",
+                "drupal 8",
                 "drupal 9",
                 "rector"
             ],
-            "time": "2020-04-17T22:07:32+00:00"
+            "transport-options": {
+                "symlink": true
+            }
         },
         {
             "name": "paragonie/random_compat",
@@ -4397,16 +4392,16 @@
         },
         {
             "name": "chi-teck/drupal-code-generator",
-            "version": "1.31.0",
+            "version": "1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Chi-teck/drupal-code-generator.git",
-                "reference": "f994157721f238175be90171f0ccc1c0aa17c276"
+                "reference": "0e045f7a7e747af3d8f603156bf4d73be5768246"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Chi-teck/drupal-code-generator/zipball/f994157721f238175be90171f0ccc1c0aa17c276",
-                "reference": "f994157721f238175be90171f0ccc1c0aa17c276",
+                "url": "https://api.github.com/repos/Chi-teck/drupal-code-generator/zipball/0e045f7a7e747af3d8f603156bf4d73be5768246",
+                "reference": "0e045f7a7e747af3d8f603156bf4d73be5768246",
                 "shasum": ""
             },
             "require": {
@@ -4438,7 +4433,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Drupal code generator",
-            "time": "2019-12-07T16:54:31+00:00"
+            "time": "2020-04-16T06:45:06+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -4493,6 +4488,16 @@
                 "certificate",
                 "ssl",
                 "tls"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-04-08T08:27:21+00:00"
         },
@@ -4677,6 +4682,12 @@
             "keywords": [
                 "Xdebug",
                 "performance"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                }
             ],
             "time": "2020-03-01T12:26:26+00:00"
         },
@@ -5222,22 +5233,22 @@
         },
         {
             "name": "consolidation/self-update",
-            "version": "1.1.5",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/self-update.git",
-                "reference": "a1c273b14ce334789825a09d06d4c87c0a02ad54"
+                "reference": "dba6b2c0708f20fa3ba8008a2353b637578849b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/self-update/zipball/a1c273b14ce334789825a09d06d4c87c0a02ad54",
-                "reference": "a1c273b14ce334789825a09d06d4c87c0a02ad54",
+                "url": "https://api.github.com/repos/consolidation/self-update/zipball/dba6b2c0708f20fa3ba8008a2353b637578849b4",
+                "reference": "dba6b2c0708f20fa3ba8008a2353b637578849b4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.0",
-                "symfony/console": "^2.8|^3|^4",
-                "symfony/filesystem": "^2.5|^3|^4"
+                "symfony/console": "^2.8|^3|^4|^5",
+                "symfony/filesystem": "^2.5|^3|^4|^5"
             },
             "bin": [
                 "scripts/release"
@@ -5259,16 +5270,16 @@
             ],
             "authors": [
                 {
-                    "name": "Greg Anderson",
-                    "email": "greg.1.anderson@greenknowe.org"
-                },
-                {
                     "name": "Alexander Menk",
                     "email": "menk@mestrona.net"
+                },
+                {
+                    "name": "Greg Anderson",
+                    "email": "greg.1.anderson@greenknowe.org"
                 }
             ],
             "description": "Provides a self:update command for Symfony Console applications.",
-            "time": "2018-10-28T01:52:03+00:00"
+            "time": "2020-04-13T02:49:20+00:00"
         },
         {
             "name": "consolidation/site-alias",
@@ -6506,16 +6517,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.3.0",
+            "version": "v4.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc"
+                "reference": "bd43ec7152eaaab3bd8c6d0aa95ceeb1df8ee120"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/9a9981c347c5c49d6dfe5cf826bb882b824080dc",
-                "reference": "9a9981c347c5c49d6dfe5cf826bb882b824080dc",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/bd43ec7152eaaab3bd8c6d0aa95ceeb1df8ee120",
+                "reference": "bd43ec7152eaaab3bd8c6d0aa95ceeb1df8ee120",
                 "shasum": ""
             },
             "require": {
@@ -6554,7 +6565,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2019-11-08T13:50:10+00:00"
+            "time": "2020-04-10T16:34:50+00:00"
         },
         {
             "name": "palantirnet/phing-drush-task",
@@ -6652,16 +6663,16 @@
         },
         {
             "name": "palantirnet/the-vagrant",
-            "version": "2.6.0",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/palantirnet/the-vagrant.git",
-                "reference": "2f77a7670a4e9c0b8d3c1b5e53daedf688df6d04"
+                "reference": "3e9299edd01241326ef4ba75aa8c35e9a4fe4765"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/palantirnet/the-vagrant/zipball/2f77a7670a4e9c0b8d3c1b5e53daedf688df6d04",
-                "reference": "2f77a7670a4e9c0b8d3c1b5e53daedf688df6d04",
+                "url": "https://api.github.com/repos/palantirnet/the-vagrant/zipball/3e9299edd01241326ef4ba75aa8c35e9a4fe4765",
+                "reference": "3e9299edd01241326ef4ba75aa8c35e9a4fe4765",
                 "shasum": ""
             },
             "require": {
@@ -6682,7 +6693,7 @@
                 }
             ],
             "description": "Install a Vagrant environment into a Drupal project.",
-            "time": "2020-02-13T18:13:48+00:00"
+            "time": "2020-04-16T21:39:18+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -8446,16 +8457,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.4",
+            "version": "3.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "dceec07328401de6211037abbb18bda423677e26"
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dceec07328401de6211037abbb18bda423677e26",
-                "reference": "dceec07328401de6211037abbb18bda423677e26",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
                 "shasum": ""
             },
             "require": {
@@ -8493,7 +8504,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-01-30T22:20:29+00:00"
+            "time": "2020-04-17T01:09:41+00:00"
         },
         {
             "name": "symfony/browser-kit",
@@ -8550,6 +8561,20 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-03-15T09:38:08+00:00"
         },
         {
@@ -8667,6 +8692,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-03-16T08:31:04+00:00"
         },
         {
@@ -8823,6 +8862,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-02-14T07:34:21+00:00"
         },
         {
@@ -9005,6 +9058,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-02-27T09:26:54+00:00"
         },
         {
@@ -9165,16 +9232,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
                 "shasum": ""
             },
             "require": {
@@ -9182,7 +9249,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "vimeo/psalm": "<3.6.0"
+                "vimeo/psalm": "<3.9.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.36 || ^7.5.13"
@@ -9209,7 +9276,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-02-14T12:15:55+00:00"
+            "time": "2020-04-18T12:12:48+00:00"
         },
         {
             "name": "webmozart/path-util",
@@ -9260,12 +9327,15 @@
     ],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "palantirnet/drupal-rector": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.3"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/develop-rector.sh
+++ b/develop-rector.sh
@@ -1,19 +1,14 @@
-# This script would run after 'composer install' and 'composer update' commands.
-# It creates relative symlinks that (might seem confusing at first) connect
-# between the new development directory (drupal-rector/) and the default
-# directory for composer packages (vendor/palantirnet/drupal-rector)
+# This script would run before 'composer install' and 'composer update' commands.
+# It clones palantirnet/drupal-rector repo to under the drupal-rector/ directory.
+# Composer is set to use the cloned repo instead of getting drupal-rector from packagist
+# (This is done through 'type: path' under repositories section in composer.json)
 
+# Clone palantirnet/drupal-rector if the drupal-rector/ directory does not exist.
 DIR="drupal-rector/"
-echo "Creating development environment under ${DIR} directory"
-
 if [ ! -d "$DIR" ]; then
+  echo "Creating development environment under ${DIR} directory"
   git clone git@github.com:palantirnet/drupal-rector.git
 fi
-
-echo "(re)create symlinks for drupal-rector, rector.yml"
-
-rm -rf vendor/palantirnet/drupal-rector
-ln -s ../../drupal-rector vendor/palantirnet/drupal-rector
 
 # Create symlink for settings file
 if [ ! -L "rector.yml" ]; then

--- a/develop-rector.sh
+++ b/develop-rector.sh
@@ -7,7 +7,7 @@
 DIR="drupal-rector/"
 if [ ! -d "$DIR" ]; then
   echo "Creating development environment under ${DIR} directory"
-  git clone git@github.com:palantirnet/drupal-rector.git
+  git clone https://github.com/palantirnet/drupal-rector.git
 fi
 
 # Create symlink for settings file

--- a/develop-rector.sh
+++ b/develop-rector.sh
@@ -7,7 +7,13 @@
 DIR="drupal-rector/"
 if [ ! -d "$DIR" ]; then
   echo "Creating development environment under ${DIR} directory"
-  git clone https://github.com/palantirnet/drupal-rector.git
+  # If a public SSH key found clone with SSH, otherwise clone with HTTPS
+  FILE="~/.ssh/id_rsa.pub"
+  if [ -f "$FILE" ]; then
+    git clone git@github.com:palantirnet/drupal-rector.git
+  else
+    git clone https://github.com/palantirnet/drupal-rector.git
+  fi
 fi
 
 # Create symlink for settings file

--- a/web/sites/default/settings.ddev.php
+++ b/web/sites/default/settings.ddev.php
@@ -14,7 +14,7 @@ $port = 3306;
 // so use the host-side bind port on docker IP
 if (empty(getenv('DDEV_PHP_VERSION') && getenv('IS_DDEV_PROJECT') == 'true')) {
   $host = "127.0.0.1";
-  $port = 32771;
+  $port = 32768;
 } 
 
 $databases['default']['default'] = array(
@@ -27,12 +27,7 @@ $databases['default']['default'] = array(
   'prefix' => "",
 );
 
-ini_set('session.gc_probability', 1);
-ini_set('session.gc_divisor', 100);
-ini_set('session.gc_maxlifetime', 200000);
-ini_set('session.cookie_lifetime', 2000000);
-
-$settings['hash_salt'] = 'PyLWaHxAnNIMregVAnBaYFirAMkPHPmdnQieZPeYTZuMRRuZXFFTHIWgZMmfSCWo';
+$settings['hash_salt'] = 'WXZTPqZnVNeOjgKvaMwBseEePTCgKRdBSapdNsROgHKsHbagxiKhucccaEhtOLVt';
 
 // This will prevent Drupal from setting read-only permissions on sites/default.
 $settings['skip_permissions_hardening'] = TRUE;
@@ -51,6 +46,7 @@ $settings['class_loader_auto_detect'] = FALSE;
 // so it should work on any Drupal 8 or 9 version.
 if (defined('CONFIG_SYNC_DIRECTORY') && empty($config_directories[CONFIG_SYNC_DIRECTORY])) {
   $config_directories[CONFIG_SYNC_DIRECTORY] = 'sites/default/files/sync';
-} else if (empty($settings['config_sync_directory'])) {
+}
+elseif (empty($settings['config_sync_directory'])) {
   $settings['config_sync_directory'] = 'sites/default/files/sync';
 }


### PR DESCRIPTION
While working on https://github.com/palantirnet/drupal-rector/pull/50, I found a better way to use local packages (https://medium.com/pvtl/local-composer-package-development-47ac5c0e5bb4).

And now the script that clones the drupal-rector is running **before** `composer install`.