### PR TITLE
Add minimal support for lando

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,0 +1,17 @@
+name: drupal-rector-sandbox
+recipe: drupal8
+config:
+  webroot: web
+  php: '7.3'
+tooling:
+  rector:
+    service: appserver
+    description: Runs drupal-rector
+    cmd: /app/vendor/bin/rector
+    dir: /app
+
+# Quick help:
+#
+# 1. Run: lando start
+# 2. Initialize the project as normal, use "lando composer ..." instead of just "composer ..."
+# 3. From the same dir as .lando.yml, run: lando rector process web/modules/custom/rector_examples/node_load.php --dry-run


### PR DESCRIPTION
Minimal support for Lando is very easy to add and maintain. Having it also reduces barriers for new contributors.

This minimal setup allows running rector from inside the appserver container managed by Lando:

```
lando rector process web/modules/custom/rector_examples/node_load.php --dry-run
```

The path to the file autocompletes naturally from the host system, which is a small but useful convenience to have.