### PR TITLE
Run errors

### DIFF
--- a/.ddev/homeadditions/.bash_aliases
+++ b/.ddev/homeadditions/.bash_aliases
@@ -1,0 +1,1 @@
+alias ll="ls -lhA"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,11 @@ Rector can update your code by running:
 
 Drupal Rector comes with a test module that you can use to confirm rules are working:
 
-`ddev . vendor/bin/rector process web/modules/custom/rector_examples --dry-run`
+`ddev . vendor/bin/rector process drupal-rector/rector_examples --dry-run`
+
+This command is aliased in the `test-rector.sh` script in project root, so you can run this from project root instead:
+
+`./test-rector.sh`
 
 ## Developing with Drupal Rector
 
@@ -60,7 +64,7 @@ environment under `drupal-project/` directory.
 1. Run Rector against the examples
 
     ```console
-    ddev . vendor/bin/rector process web/modules/custom/rector_examples --dry-run
+    ddev . vendor/bin/rector process drupal-rector/rector_examples --dry-run
     ```
 
 1. Submit a PR to https://github.com/palantirnet/drupal-rector.
@@ -143,6 +147,7 @@ This project was built more or less using these steps.
 - Update `composer.json` to use the version side-loaded.
 - Add `PhpUnit` since it doesn't get installed by default and is needed for some rules.
 - Add a `docker-compose.env.yaml` file for DDEV to support XDebug
+- Add `test-rector.sh` script for testing shortcuts.
 
 ----
 Copyright 2017-2021 Palantir.net, Inc.

--- a/develop-rector.sh
+++ b/develop-rector.sh
@@ -23,10 +23,3 @@ if [ ! -e "rector.php" ]; then
   echo "Copying rector.php into the document root directory"
   cp drupal-rector/rector.php .
 fi
-
-# Create symlink for rector_examples to be in drupal's default module directory
-if [ ! -L "web/modules/custom/rector_examples" ]; then
-  echo "Creating a symlink for web/modules/custom/rector_examples..."
-  mkdir -p web/modules/custom
-  ln -s ../../../drupal-rector/rector_examples web/modules/custom/rector_examples
-fi

--- a/git-swap-origin.sh
+++ b/git-swap-origin.sh
@@ -1,0 +1,5 @@
+# If running composer from inside ddev, we may not be able to install the repo
+# via ssh. This script fixes that issue and must be run from the host machine.
+rm -rf drupal-rector
+echo "Replace http checkout with ssh."
+git clone git@github.com:palantirnet/drupal-rector.git

--- a/test-rector.sh
+++ b/test-rector.sh
@@ -1,0 +1,7 @@
+DIR="drupal-rector/"
+if [ ! -d "$DIR" ]; then
+  echo "drupal-rector not found."
+else
+  echo "ddev . vendor/bin/rector process drupal-rector/rector_examples --dry-run"
+  ddev . vendor/bin/rector process drupal-rector/rector_examples --dry-run
+fi


### PR DESCRIPTION
We were running into persistent errors when using symlinks to run the sample tests. This corrects the error and makes changes associated with ddev and composer.

- Removes the symlink to move files to web/modules/custom
- Adds a .test-rector.sh to replicate the dry-run command in the drupal-rector folder directly
- Adds a git-swap-origin.sh because ddev composer may not pick up ssh keys
